### PR TITLE
nesting emiting functionality in main viewport and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This tools helps you to test socket.io servers.
 ### TODOs
 1. ~~Functional event emit modal~~
 2. ~~Add events and socket.io URL to page URL so that it can be shared with set inputs~~
-3. Add toggle button to stringify or not to stringify data while emitting
+3. ~~Add toggle button to stringify or not to stringify data while emitting~~
 3. Store history of emits - and can be re-sent in just one click
-3. Change timestamps to better formatted time
+3. ~~Change timestamps to better formatted time~~
 4. Fix URL hashes - if the has only has url value, initiate the app with the connected URL, and no extra event should be added
 4. Show socket.id somewhere in the UI (easy to copy)
 3. Helper links/buttons to add basic socketio evnets like reconnect, etc.

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 var eventsToListen = ['message'];
 var socket = {};
@@ -30,7 +30,7 @@ $(function () {
       socket = io(url, {transports: ['websocket']});
       setHash();
       socket.on('connect', function () {
-        $("#emitData input, textarea, button").prop('disabled', false);
+        $("#submitEmit").prop('disabled', false);
         clearInterval(disconnectedInerval);
         document.title = title;
         $('.disconnected-alert').hide();
@@ -38,6 +38,7 @@ $(function () {
         $("#connectionPanel").prepend('<p><span class="text-muted">'+Date.now()+'</span> Connected</p>');
       });
       socket.on('disconnect', function (sock) {
+        $("#submitEmit").prop('disabled', true);
         disconnectedInerval = setInterval(function(){
           if(document.title === "Disconnected") {
             document.title = title;
@@ -70,9 +71,12 @@ $(function () {
   $("#emitData").submit(function (e) {
     if(socket.io) {
       var event = $("#emitData #event-name").val().trim();
-      var data = $("#emitData #data-text").val().trim();
+      var data;
       if($('#emitAsJSON').is(":checked")){
-        data = JSON.parse(data);
+          data = parseJSONForm();
+      }
+      if($('#emitAsPlaintext').is(":checked")){
+          data = $("#emitData #data-text").val().trim();
       }
       if(event !== '' && data !== '') {
         $('#emitData #event-name').val('');
@@ -90,7 +94,7 @@ $(function () {
 
   $("#addNewJsonField").click(function (e) {
     e.preventDefault();
-    var template = "<div class=\"form-inline\"><div class=\"form-group\"><input type=\"text\" class=\"form-control\"></div> <div class=\"form-group\"><input type=\"text\" class=\"form-control\"></div> <div class=\"form-group\"><button class=\"btn btn-xs remove\" type=\"button\" class=\"btn\">remove</button></div></div>";
+    var template = "<div class=\"form-inline\"><div class=\"form-group\"><input type=\"text\" class=\"form-control key\"></div> <div class=\"form-group\"><input type=\"text\" class=\"form-control value\"></div> <div class=\"form-group\"><button class=\"btn btn-xs remove\" type=\"button\" class=\"btn\">remove</button></div></div>";
     $("#jsonData").append(template);
   });
 
@@ -137,6 +141,15 @@ function registerEvents() {
       });
     });
   }
+}
+
+function parseJSONForm() {
+    var result = {};
+    $("#jsonData.form-inline").each(function (index, el) {
+        var k = $(el).find('input.key').val().trim();
+        result[k] = $(el).find('input.value').val().trim();
+    });
+    return result
 }
 
 function makePanel(event) {

--- a/app.js
+++ b/app.js
@@ -10,6 +10,8 @@ $(function () {
   $('#jsonData').hide();
   $('.emitted-msg').hide();
   $('.emitted-failure-msg').hide();
+  $('.listen-failure-msg').hide();
+  $('.listen-added-msg').hide();
   $('.disconnected-alert, .connected-alert').hide();
   $('#eventPanels').prepend(makePanel('message'));
   $('input[type=radio][name=emitAs]').change(function () {
@@ -59,13 +61,15 @@ $(function () {
   $("#addListener").submit(function (e) {
     e.preventDefault();
     var event = $("#addListener input:first").val().trim();
-    if(event !== '') {
+    if(event.length!==0 && eventsToListen.indexOf(event) === -1) {
       eventsToListen.push(event);
       $('#eventPanels').prepend(makePanel(event));
       $("#addListener input:first").val('');
       setHash();
       registerEvents();
+      $('.listen-added-msg').show().delay(1000).fadeOut(1000);
     } else {
+      $('.listen-failure-msg').show().delay(1500).fadeOut(1000);
       console.error('Invalid event name');
     }
   });
@@ -85,7 +89,7 @@ $(function () {
         socket.emit(event, data);
         $('.emitted-msg').show().delay(700).fadeOut(1000)
       } else {
-        $('.emitted-failure-msg').show().delay(700).fadeOut(1000)
+        $('.emitted-failure-msg').show().delay(700).fadeOut(1000);
         console.error('Emitter - Invalid event name or data');
       }
     } else {
@@ -141,7 +145,8 @@ function registerEvents() {
         if(!data) {
             data = '-- NO DATA --'
         }
-        $("#panel-"+value+"-content").prepend('<p><span class="text-muted">'+getFormattedNowTime()+'</span><strong> '+JSON.stringify(data)+'</strong></p>');
+        var elementToExtend = $("#eventPanels").find("[data-windowId='" + value + "']");
+        elementToExtend.prepend('<p><span class="text-muted">' + getFormattedNowTime() + '</span><strong> ' + JSON.stringify(data) + '</strong></p>');
       });
     });
   }
@@ -167,7 +172,7 @@ function parseJSONForm() {
 }
 
 function makePanel(event) {
-  return '<div class="panel panel-primary" id="panel-'+event+'"> <div class="panel-heading"> <button type="button" class="btn btn-warning btn-xs pull-right" data-toggle="collapse" data-target="#panel-'+event+'-content" aria-expanded="false" aria-controls="panel-'+event+'-content">Toggle panel</button> <h3 class="panel-title">On "'+event+'" Events</h3> </div> <div id="panel-'+event+'-content" class="panel-body"></div> </div>';
+  return '<div class="panel panel-primary"> <div class="panel-heading"> <button type="button" class="btn btn-warning btn-xs pull-right" data-toggle="collapse" data-target="#panel-'+event+'-content" aria-expanded="false" aria-controls="panel-'+event+'-content">Toggle panel</button> <h3 class="panel-title">On "'+event+'" Events</h3> </div> <div data-windowId="'+event+'" class="panel-body"></div> </div>';
 }
 
 function getFormattedNowTime() {

--- a/app.js
+++ b/app.js
@@ -7,8 +7,19 @@ var url = '';
 var title = document.title;
 
 $(function () {
+  $('#jsonData').hide();
   $('.disconnected-alert, .connected-alert').hide();
   $('#eventPanels').prepend(makePanel('message'));
+  $('input[type=radio][name=emitAs]').change(function () {
+    if (this.value === 'JSON') {
+      $('#plainTextData').hide();
+      $('#jsonData').show();
+    }
+    if (this.value === 'plaintext') {
+      $('#plainTextData').show();
+      $('#jsonData').hide();
+    }
+  });
 
   $("#connect").submit(function (e) {
     e.preventDefault();
@@ -19,7 +30,7 @@ $(function () {
       socket = io(url, {transports: ['websocket']});
       setHash();
       socket.on('connect', function () {
-        $('#emitDataMenuButton').removeClass('disabled');
+        $("#emitData input, textarea, button").prop('disabled', false);
         clearInterval(disconnectedInerval);
         document.title = title;
         $('.disconnected-alert').hide();
@@ -27,7 +38,6 @@ $(function () {
         $("#connectionPanel").prepend('<p><span class="text-muted">'+Date.now()+'</span> Connected</p>');
       });
       socket.on('disconnect', function (sock) {
-        $('#emitDataMenuButton').addClass('disabled');
         disconnectedInerval = setInterval(function(){
           if(document.title === "Disconnected") {
             document.title = title;
@@ -77,6 +87,19 @@ $(function () {
     }
     e.preventDefault();
   });
+
+  $("#addNewJsonField").click(function (e) {
+    e.preventDefault();
+    var template = "<div class=\"form-inline\"><div class=\"form-group\"><input type=\"text\" class=\"form-control\"></div> <div class=\"form-group\"><input type=\"text\" class=\"form-control\"></div> <div class=\"form-group\"><button class=\"btn btn-xs remove\" type=\"button\" class=\"btn\">remove</button></div></div>";
+    $("#jsonData").append(template);
+  });
+
+  $("#jsonData").on('click', '.remove', function (e) {
+    e.preventDefault();
+    $(this).closest(".form-inline").remove();
+  });
+
+
   processHash();
 });
 

--- a/app.js
+++ b/app.js
@@ -144,12 +144,22 @@ function registerEvents() {
 }
 
 function parseJSONForm() {
-    var result = {};
-    $("#jsonData.form-inline").each(function (index, el) {
-        var k = $(el).find('input.key').val().trim();
-        result[k] = $(el).find('input.value').val().trim();
+    var result = "{";
+    var formInputs = $('#jsonData').find('.form-inline');
+    formInputs.each(function (index, el) {
+        var key = $(el).find('.key').val().trim();
+        if(!key.length){
+         return true;
+        }
+        result += "\"" + key + "\"";
+        result += (" : ");
+        result += "\"" + ($(el).find('.value').val().trim()) + "\"";
+        result += ",";
     });
-    return result
+    result = result.slice(0, -1);
+    result += "}";
+    console.log("json to emit " + result);
+    return JSON.parse(result);
 }
 
 function makePanel(event) {

--- a/app.js
+++ b/app.js
@@ -8,6 +8,8 @@ var title = document.title;
 
 $(function () {
   $('#jsonData').hide();
+  $('.emitted-msg').hide();
+  $('.emitted-failure-msg').hide();
   $('.disconnected-alert, .connected-alert').hide();
   $('#eventPanels').prepend(makePanel('message'));
   $('input[type=radio][name=emitAs]').change(function () {
@@ -79,11 +81,11 @@ $(function () {
           data = $("#emitData #data-text").val().trim();
       }
       if(event !== '' && data !== '') {
-        $('#emitData #event-name').val('');
-        $("#emitData #data-text").val('');
+        console.log('Emitter - emitted: '+data);
         socket.emit(event, data);
-        $('#emitDataModal').modal('toggle');
+        $('.emitted-msg').show().delay(700).fadeOut(1000)
       } else {
+        $('.emitted-failure-msg').show().delay(700).fadeOut(1000)
         console.error('Emitter - Invalid event name or data');
       }
     } else {
@@ -136,7 +138,9 @@ function registerEvents() {
   if(socket.io) {
     $.each(eventsToListen, function (index, value) {
       socket.on(value, function (data) {
-        data = data === undefined ? '-- NO DATA --' : data;
+        if(!data) {
+            data = '-- NO DATA --'
+        }
         $("#panel-"+value+"-content").prepend('<p><span class="text-muted">'+getFormattedNowTime()+'</span><strong> '+JSON.stringify(data)+'</strong></p>');
       });
     });

--- a/app.js
+++ b/app.js
@@ -35,7 +35,7 @@ $(function () {
         document.title = title;
         $('.disconnected-alert').hide();
         $('.connected-alert').show().delay(5000).fadeOut(1000);
-        $("#connectionPanel").prepend('<p><span class="text-muted">'+Date.now()+'</span> Connected</p>');
+        $("#connectionPanel").prepend('<p><span class="text-muted">'+getFormattedNowTime()+'</span> Connected</p>');
       });
       socket.on('disconnect', function (sock) {
         $("#submitEmit").prop('disabled', true);
@@ -48,7 +48,7 @@ $(function () {
         }, 800);
         $('.disconnected-alert').hide();
         $('.disconnected-alert').show();
-        $("#connectionPanel").prepend('<p><span class="text-muted">'+Date.now()+'</span> Disconnected --> '+sock+'</p>');
+        $("#connectionPanel").prepend('<p><span class="text-muted">'+getFormattedNowTime()+'</span> Disconnected --> '+sock+'</p>');
       });
       registerEvents();
     }
@@ -137,7 +137,7 @@ function registerEvents() {
     $.each(eventsToListen, function (index, value) {
       socket.on(value, function (data) {
         data = data === undefined ? '-- NO DATA --' : data;
-        $("#panel-"+value+"-content").prepend('<p><span class="text-muted">'+Date.now()+'</span><strong> '+JSON.stringify(data)+'</strong></p>');
+        $("#panel-"+value+"-content").prepend('<p><span class="text-muted">'+getFormattedNowTime()+'</span><strong> '+JSON.stringify(data)+'</strong></p>');
       });
     });
   }
@@ -154,4 +154,12 @@ function parseJSONForm() {
 
 function makePanel(event) {
   return '<div class="panel panel-primary" id="panel-'+event+'"> <div class="panel-heading"> <button type="button" class="btn btn-warning btn-xs pull-right" data-toggle="collapse" data-target="#panel-'+event+'-content" aria-expanded="false" aria-controls="panel-'+event+'-content">Toggle panel</button> <h3 class="panel-title">On "'+event+'" Events</h3> </div> <div id="panel-'+event+'-content" class="panel-body"></div> </div>';
+}
+
+function getFormattedNowTime() {
+    var now = new Date();
+    return now.getHours() + ":" +
+        now.getMinutes() + ":" +
+        now.getSeconds() + ":" +
+        now.getMilliseconds();
 }

--- a/index.html
+++ b/index.html
@@ -72,31 +72,41 @@
     </div>
   </nav>
   <div class="container">
-      <div class="row well">
+      <ul class="nav nav-tabs" role="tablist">
+          <li role="presentation" class="active">
+              <a href="#listening" aria-controls="profile" role="tab" data-toggle="tab">Listening</a>
+          </li>
+          <li role="presentation">
+              <a href="#emiting" aria-controls="home" role="tab" data-toggle="tab">Emiting</a>
+          </li>
+      </ul>
+      <div class="tab-content">
+      <div class="row tab-pane" role="tabpanel" id="emiting">
           <div class="col-sm-12">
               <div id="emitPanel">
-                  <h1>Emiting</h1>
                   <form id="emitData">
-                      <div class="form-group">
-                          <label for="event-name" class="control-label">Event:</label>
-                          <input type="text" class="form-control" id="event-name" disabled>
+                      <div class="form-group well">
+                          <div class="col-sm-5">
+                              <input type="text" class="form-control" id="event-name" placeholder="Event name">
+                          </div>
+                          <button id="submitEmit" type="submit" class="btn btn-success" disabled>Emit</button>
                       </div>
                       <div class="form-group">
                           <label class="radio-inline">
                               <input id="emitAsPlaintext" type="radio" name="emitAs"
-                                     value="plaintext" checked="checked" disabled/>
+                                     value="plaintext" checked="checked" />
                               Send data as plaintext
                           </label>
                           <label class="radio-inline">
                               <input id="emitAsJSON" type="radio" name="emitAs"
-                                     value="JSON" disabled/>
+                                     value="JSON" />
                               Send data as JSON object
                           </label>
                       </div>
                       <div class="form-group">
                           <div id="plainTextData">
                               <label for="data-text" class="control-label">Data:</label>
-                              <textarea class="form-control" id="data-text" disabled></textarea>
+                              <textarea class="form-control" id="data-text" ></textarea>
                           </div>
                       </div>
                       <div class="form-group">
@@ -107,37 +117,28 @@
                               <button id="addNewJsonField" type="button" class="btn btn-xs btn-warning">add new</button>
                               <div class="form-inline">
                                   <div class="form-group">
-                                      <input type="text" class="form-control">
+                                      <input type="text" class="form-control key">
                                   </div>
                                   <div class="form-group">
-                                      <input type="text" class="form-control">
+                                      <input type="text" class="form-control value">
                                   </div>
                               </div>
                           </div>
-                      </div>
-
-                      <div class="form-group ">
-                          <button type="submit" class="btn btn-primary" disabled>Emit</button>
                       </div>
                   </form>
               </div>
           </div>
       </div>
-
-    <div class="row">
+    <div class="row tab-pane active" role="tabpanel" id="listening">
       <div class="col-sm-12">
-        <h1>Listening</h1>
-          <!--  col-sm-offset-3 -->
-        <div id="addNewPanel">
           <div class="well">
-            <form class="form-inline text-center" id="addListener">
-              <div class="form-group has-success long-input">
-                <label class="sr-only" for="exampleInputEmail3">Event</label>
-                <input type="text" class="eventName form-control inline-right-margin" id="exampleInputEmail3" placeholder="Event name">
+            <form id="addListener">
+              <div class="col-sm-5">
+                <input type="text" class="eventName form-control" id="exampleInputEmail3" placeholder="Event name">
               </div>
-              <button type="submit" class="btn btn-success">Listen</button>
+                <button type="submit" class="btn btn-success">Listen</button>
+
             </form>
-          </div>
         </div>
       </div>
       <div class="col-sm-12">
@@ -154,6 +155,7 @@
         </div>
       </div>
     </div>
+  </div>
   </div>
 
   <div class="alert alert-danger connection-alert disconnected-alert text-center">

--- a/index.html
+++ b/index.html
@@ -139,7 +139,8 @@
                 <input type="text" class="eventName form-control" id="exampleInputEmail3" placeholder="Event name">
               </div>
                 <button type="submit" class="btn btn-success">Listen</button>
-
+                <span class="label label-danger listen-failure-msg">Can't add duplicated or empty listener</span>
+                <span class="label label-primary listen-added-msg">Listener added</span>
             </form>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -90,6 +90,8 @@
                               <input type="text" class="form-control" id="event-name" placeholder="Event name">
                           </div>
                           <button id="submitEmit" type="submit" class="btn btn-success" disabled>Emit</button>
+                          <span class="label label-primary emitted-msg">Event emitted!</span>
+                          <span class="label label-danger emitted-failure-msg">Event failure</span>
                       </div>
                       <div class="form-group">
                           <label class="radio-inline">
@@ -105,7 +107,7 @@
                       </div>
                       <div class="form-group">
                           <div id="plainTextData">
-                              <label for="data-text" class="control-label">Data:</label>
+                              <label for="data-text" class="control-label">Data: plaintext</label>
                               <textarea class="form-control" id="data-text" ></textarea>
                           </div>
                       </div>

--- a/index.html
+++ b/index.html
@@ -12,22 +12,22 @@
     margin-right: 10px;
     width: 95%;
   }
-  
+
   .long-input {
     width: 300px;
   }
-  
+
   .long-input input {
     width: 98% !important;
   }
-  
+
   #eventPanels .panel-body {
     max-height: 318px;
     overflow: scroll;
     overflow-y: scroll;
     overflow-x: hidden;
   }
-  
+
   .connection-alert {
     width: 300px;
     position: fixed;
@@ -61,7 +61,6 @@
       </div>
       <p class="navbar-text">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<iframe src="https://ghbtns.com/github-btn.html?user=amritb&repo=socketio-client-tool&type=star&count=true&size=small" frameborder="0" scrolling="0" width="170px" height="20px"></iframe></p>
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-        <button id="emitDataMenuButton" type="button" class="btn btn-warning navbar-btn navbar-right disabled" data-toggle="modal" data-target="#emitDataModal">Emit data</button>
         <p class="navbar-text navbar-right">&nbsp; &nbsp;</p>
         <form id="connect" class="navbar-form navbar-right" role="search" style="margin-right: -30px;">
           <div class="form-group long-input">
@@ -73,9 +72,62 @@
     </div>
   </nav>
   <div class="container">
+      <div class="row well">
+          <div class="col-sm-12">
+              <div id="emitPanel">
+                  <h1>Emiting</h1>
+                  <form id="emitData">
+                      <div class="form-group">
+                          <label for="event-name" class="control-label">Event:</label>
+                          <input type="text" class="form-control" id="event-name" disabled>
+                      </div>
+                      <div class="form-group">
+                          <label class="radio-inline">
+                              <input id="emitAsPlaintext" type="radio" name="emitAs"
+                                     value="plaintext" checked="checked" disabled/>
+                              Send data as plaintext
+                          </label>
+                          <label class="radio-inline">
+                              <input id="emitAsJSON" type="radio" name="emitAs"
+                                     value="JSON" disabled/>
+                              Send data as JSON object
+                          </label>
+                      </div>
+                      <div class="form-group">
+                          <div id="plainTextData">
+                              <label for="data-text" class="control-label">Data:</label>
+                              <textarea class="form-control" id="data-text" disabled></textarea>
+                          </div>
+                      </div>
+                      <div class="form-group">
+                          <div id="jsonData">
+                              <div>
+                                  <label for="data-text" class="control-label">Data: JSON (key, value)</label>
+                              </div>
+                              <button id="addNewJsonField" type="button" class="btn btn-xs btn-warning">add new</button>
+                              <div class="form-inline">
+                                  <div class="form-group">
+                                      <input type="text" class="form-control">
+                                  </div>
+                                  <div class="form-group">
+                                      <input type="text" class="form-control">
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+
+                      <div class="form-group ">
+                          <button type="submit" class="btn btn-primary" disabled>Emit</button>
+                      </div>
+                  </form>
+              </div>
+          </div>
+      </div>
+
     <div class="row">
       <div class="col-sm-12">
-        <!--  col-sm-offset-3 -->
+        <h1>Listening</h1>
+          <!--  col-sm-offset-3 -->
         <div id="addNewPanel">
           <div class="well">
             <form class="form-inline text-center" id="addListener">
@@ -111,40 +163,9 @@
     <strong>Connected!</strong>
   </div>
 
-  <div class="modal fade" id="emitDataModal" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title" id="myModalLabel">Emit data</h4>
-        </div>
-        <form id="emitData">
-          <div class="modal-body">
-            <div class="form-group">
-              <label for="event-name" class="control-label">Event:</label>
-              <input type="text" class="form-control" id="event-name">
-            </div>
-            <div class="form-group">
-              <label for="data-text" class="control-label">Data:</label>
-              <textarea class="form-control" id="data-text"></textarea>
-            </div>
-            <div class="form-group">
-              <label>
-                <input id="emitAsJSON" type="checkbox" name="emitAsJSON" value="emitAsJSON"/>
-                Send data as JSON object
-              </label>
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button type="submit" class="btn btn-primary">Emit</button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.3.5/socket.io.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
   <script src="app.js"></script>
 </body>
 


### PR DESCRIPTION
Hi, sorry for such a big pull request. In short: 
slightly redesign UI - I nested Emit functionality in a main viewport and use bootstrap tabs to separate it from listening. I also fix 2 items from the list (`Change timestamps to better formatted time` for sure, regarding `Add toggle button to stringify or not to stringify data while emitting` i'm not sure, but i think it's what you meant:) The rest info is in commit comments.