### PR TITLE
Parse plaintext - avoid string sending

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,7 +100,12 @@ $(function() {
         data = parseJSONForm();
       }
       if ($('#emitAsPlaintext').is(":checked")) {
-        data = $("#emitData #data-text").val().trim();
+        var text = $("#emitData #data-text").val().trim();
+        try {
+          data = JSON.parse(text);
+        } catch (ex) {
+          data = text;
+        }
       }
       if (event !== '' && data !== '') {
         var emitData = {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "socketio-client-tool",
+  "version": "1.0.0",
+  "description": "This tools helps you to test socket.io servers.",
+  "license": "MIT",
+  "scripts": {
+    "start": "node node_modules/http-server/bin/http-server"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amritb/socketio-client-tool.git"
+  },
+  "devDependencies": {
+    "@types/jquery": "^3.3.14",
+    "@types/pouchdb": "^6.3.2",
+    "@types/socket.io-client": "^1.4.32",
+    "http-server": "^0.11.1"
+  }
+}


### PR DESCRIPTION
with this you can send pure numbers, `null`, nested JSONs and more...

Related issues:
#14
#12 