### PR TITLE
Fixed issue #32 related to reconnecting

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,7 +93,6 @@ $(function() {
       });
 
       socket.on('disconnect', function (sock) {
-        socket = null;
 
         $("#submitEmit").prop('disabled', true);
         setFormInputs(false, false);


### PR DESCRIPTION
Issue #32 Fixed. In this once socket is reconnected after interruptions, the socket emits stop working because the socket object is changed to null on disconnect. I have removed that line to prevent socket becoming null & make the event emitter work.