### PR TITLE
Fix: Make clearEvents button work in eventHistory & eventAckRes Panels

### DIFF
--- a/app.js
+++ b/app.js
@@ -274,7 +274,7 @@ function clearEvents(event) {
   if (event === 'connectionPanel') {
     $('#connectionPanel').empty();
   } else {
-    $('#eventPanels').find("[data-windowId='" + event + "']").empty();
+    $('.tab-content').find("[data-windowId='" + event + "']").empty();
   }
 }
 


### PR DESCRIPTION
I have changed the selector for clearEvents function which clears panel to cover whole `.tab-content` box instead of just `#eventPanels` to make clear event button work in eventHistory & eventAckRes panels