### PR TITLE
fix(react-client-tool): referring config.url which is undefined

### DIFF
--- a/react-client-tool/src/App.jsx
+++ b/react-client-tool/src/App.jsx
@@ -64,7 +64,7 @@ function App() {
         return {
           connected: true,
           loading: false,
-          server: connData.url,
+          server: connData.server,
           socketId: socket.id,
           config: connData.config,
           errors: []


### PR DESCRIPTION
fixes #69 

Once connected, the setConnData in the useEffect was referring to `config.url` which is undefined, rather it should have been referring `config.server`.